### PR TITLE
treewide: fix datetype/datatype typo

### DIFF
--- a/applications/luci-app-aria2/luasrc/model/cbi/aria2.lua
+++ b/applications/luci-app-aria2/luasrc/model/cbi/aria2.lua
@@ -135,7 +135,7 @@ o = s:taboption("task", Value, "max_concurrent_downloads", translate("Max concur
 o.placeholder = "5"
 
 o = s:taboption("task", Value, "max_connection_per_server", translate("Max connection per server"), "1-16")
-o.datetype = "range(1, 16)"
+o.datatype = "range(1, 16)"
 o.placeholder = "1"
 
 o = s:taboption("task", Value, "min_split_size", translate("Min split size"), "1M-1024M")

--- a/applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua
+++ b/applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua
@@ -27,7 +27,7 @@ o.optional = true
 o.datatype = "uinteger"
 
 o = s:option(Value, "localip", translate("IP of listening side"))
-o.datetype = "ipaddr"
+o.datatype = "ipaddr"
 
 o = s:option(Value, "firstremoteip", translate("First remote IP"))
 o.datatype = "ipaddr"


### PR DESCRIPTION
Fix the "datetype" typo also in 17.01

Signed-off-by: Hannu Nyman <hannu.nyman@iki.fi>